### PR TITLE
Update for JupyterLab 0.33

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Shortcuts this extension introduces:
 ## Install
 ### Prerequisites
 
-* JupyterLab 0.32
+* JupyterLab 0.33
 
 ### Install or upgrade
 

--- a/package.json
+++ b/package.json
@@ -34,10 +34,10 @@
     "extension": true
   },
   "dependencies": {
-    "@jupyterlab/application": "^0.16.1",
-    "@jupyterlab/codemirror": "^0.16.1",
-    "@jupyterlab/cells": "^0.16.1",
-    "@jupyterlab/notebook": "^0.16.1",
+    "@jupyterlab/application": "^0.17.2",
+    "@jupyterlab/codemirror": "^0.17.2",
+    "@jupyterlab/cells": "^0.17.2",
+    "@jupyterlab/notebook": "^0.17.2",
     "@phosphor/commands": "^1.4.0",
     "@phosphor/coreutils": "^1.3.0",
     "@phosphor/domutils": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyterlab_vim",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Code cell vim bindings",
   "author": "Jacques Kvam",
   "main": "lib/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -211,9 +211,9 @@ function activateCellVim(app: JupyterLab, tracker: INotebookTracker): Promise<vo
                 const current = getCurrent(args);
 
                 if (current) {
-                    const { context, notebook } = current;
-                    NotebookActions.runAndAdvance(notebook, context.session);
-                    current.notebook.mode = 'edit';
+                    const { context, content } = current;
+                    NotebookActions.runAndAdvance(content, context.session);
+                    current.content.mode = 'edit';
                 }
             },
             isEnabled
@@ -224,9 +224,9 @@ function activateCellVim(app: JupyterLab, tracker: INotebookTracker): Promise<vo
                 const current = getCurrent(args);
 
                 if (current) {
-                    const { context, notebook } = current;
-                    NotebookActions.run(notebook, context.session);
-                    current.notebook.mode = 'edit';
+                    const { context, content } = current;
+                    NotebookActions.run(content, context.session);
+                    current.content.mode = 'edit';
                 }
             },
             isEnabled
@@ -237,9 +237,9 @@ function activateCellVim(app: JupyterLab, tracker: INotebookTracker): Promise<vo
                 const current = getCurrent(args);
 
                 if (current) {
-                    const { notebook } = current;
-                    NotebookActions.cut(notebook);
-                    notebook.mode = 'edit';
+                    const { content } = current;
+                    NotebookActions.cut(content);
+                    content.mode = 'edit';
                 }
             },
             isEnabled
@@ -250,9 +250,9 @@ function activateCellVim(app: JupyterLab, tracker: INotebookTracker): Promise<vo
                 const current = getCurrent(args);
 
                 if (current) {
-                    const { notebook } = current;
-                    NotebookActions.copy(notebook);
-                    notebook.mode = 'edit';
+                    const { content } = current;
+                    NotebookActions.copy(content);
+                    content.mode = 'edit';
                 }
             },
             isEnabled
@@ -263,9 +263,9 @@ function activateCellVim(app: JupyterLab, tracker: INotebookTracker): Promise<vo
                 const current = getCurrent(args);
 
                 if (current) {
-                    const { notebook } = current;
-                    NotebookActions.paste(notebook, 'below');
-                    notebook.mode = 'edit';
+                    const { content } = current;
+                    NotebookActions.paste(content, 'below');
+                    content.mode = 'edit';
                 }
             },
             isEnabled
@@ -276,9 +276,9 @@ function activateCellVim(app: JupyterLab, tracker: INotebookTracker): Promise<vo
                 const current = getCurrent(args);
 
                 if (current) {
-                    const { notebook } = current;
-                    NotebookActions.mergeCells(notebook);
-                    current.notebook.mode = 'edit';
+                    const { content } = current;
+                    NotebookActions.mergeCells(content);
+                    current.content.mode = 'edit';
                 }
             },
             isEnabled
@@ -289,8 +289,8 @@ function activateCellVim(app: JupyterLab, tracker: INotebookTracker): Promise<vo
                 const current = getCurrent(args);
 
                 if (current) {
-                    const { notebook } = current;
-                    let editor = notebook.activeCell.editor as CodeMirrorEditor;
+                    const { content } = current;
+                    let editor = content.activeCell.editor as CodeMirrorEditor;
                     (CodeMirror as any).Vim.handleKey(editor.editor, '<Esc>');
                 }
             },
@@ -302,10 +302,10 @@ function activateCellVim(app: JupyterLab, tracker: INotebookTracker): Promise<vo
                 const current = getCurrent(args);
 
                 if (current) {
-                    if (current.notebook.activeCell.model.type === 'markdown') {
-                        (current.notebook.activeCell as MarkdownCell).rendered = true;
+                    if (current.content.activeCell.model.type === 'markdown') {
+                        (current.content.activeCell as MarkdownCell).rendered = true;
                     }
-                    return NotebookActions.selectBelow(current.notebook);
+                    return NotebookActions.selectBelow(current.content);
                 }
             },
             isEnabled
@@ -316,10 +316,10 @@ function activateCellVim(app: JupyterLab, tracker: INotebookTracker): Promise<vo
                 const current = getCurrent(args);
 
                 if (current) {
-                    if (current.notebook.activeCell.model.type === 'markdown') {
-                        (current.notebook.activeCell as MarkdownCell).rendered = true;
+                    if (current.content.activeCell.model.type === 'markdown') {
+                        (current.content.activeCell as MarkdownCell).rendered = true;
                     }
-                    return NotebookActions.selectAbove(current.notebook);
+                    return NotebookActions.selectAbove(current.content);
                 }
             },
             isEnabled
@@ -330,11 +330,11 @@ function activateCellVim(app: JupyterLab, tracker: INotebookTracker): Promise<vo
                 const current = getCurrent(args);
 
                 if (current) {
-                    current.notebook.activeCellIndex = 0;
-                    current.notebook.deselectAll();
+                    current.content.activeCellIndex = 0;
+                    current.content.deselectAll();
                     ElementExt.scrollIntoViewIfNeeded(
-                        current.notebook.node,
-                        current.notebook.activeCell.node
+                        current.content.node,
+                        current.content.activeCell.node
                     );
                 }
             },
@@ -346,11 +346,11 @@ function activateCellVim(app: JupyterLab, tracker: INotebookTracker): Promise<vo
                 const current = getCurrent(args);
 
                 if (current) {
-                    current.notebook.activeCellIndex = current.notebook.widgets.length - 1;
-                    current.notebook.deselectAll();
+                    current.content.activeCellIndex = current.content.widgets.length - 1;
+                    current.content.deselectAll();
                     ElementExt.scrollIntoViewIfNeeded(
-                        current.notebook.node,
-                        current.notebook.activeCell.node
+                        current.content.node,
+                        current.content.activeCell.node
                     );
                 }
             },
@@ -362,8 +362,8 @@ function activateCellVim(app: JupyterLab, tracker: INotebookTracker): Promise<vo
                 const current = getCurrent(args);
 
                 if (current) {
-                    let er = current.notebook.activeCell.inputArea.node.getBoundingClientRect();
-                    current.notebook.scrollToPosition(er.bottom, 0);
+                    let er = current.content.activeCell.inputArea.node.getBoundingClientRect();
+                    current.content.scrollToPosition(er.bottom, 0);
                 }
             },
             isEnabled

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
     "declaration": true,
     "noImplicitAny": true,
     "noEmitOnError": true,


### PR DESCRIPTION
New JupyterLab was just released a few days ago so it's about time to make my favourite extension work with it!

Changes seem minor, bump some version numbers and `notebook` was renamed to `content` in `NotebookPanel`.

Not quite sure what the `allowSyntheticDefaultImports": true` means, but without it I get this error: `node_modules/@jupyterlab/codemirror/lib/editor.d.ts(1,8): error TS1192: Module '"/Users/andreas/tmp/jupyterlab_vim/node
_modules/@types/codemirror/index"' has no default export.`

Should fix https://github.com/jwkvam/jupyterlab-vim/issues/51