### PR TITLE
Updated the prerequisite version to 0.35

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Shortcuts this extension introduces:
 ## Install
 ### Prerequisites
 
-* JupyterLab 0.34
+* JupyterLab 0.35
 
 ### Install or upgrade
 
@@ -95,7 +95,7 @@ jupyter labextension uninstall jupyterlab_vim
 
 ### Development
 
-For a development install (requires npm version 4 or later), do the following in the repository directory:
+For a development install (requires npm version 4 or later), do the following in the repository directory. **Please note**, you need to make sure that you satisfy all the prerequisites, i.e. the JupyterLab version.
 
 ```bash
 jlpm install


### PR DESCRIPTION
Upon wrestling with issue #68, it turned out that I do need JupyterLab 0.35.1 to get the new `jupyterlab-vim` to build locally.

Please finish the following when submitting a pull request:

 ==> I was simply editing the documentation. Will skip it for now.

- [x] *Skipped* Add a line to `History.md` briefly documenting the change.

If this is a release, additionally do the following:

- [x] *Skipped* Bump the package version in `package.json`
- [x] *Skipped* Update the dependencies in `package.json`
- [x] *Skipped* Run `jlpm install` to update `yarn.lock`

Thanks!
